### PR TITLE
Add files via upload

### DIFF
--- a/validator/README.TXT
+++ b/validator/README.TXT
@@ -1,0 +1,84 @@
+# NOTE: all submissions have ROLLBACK for testing (remove line 88 & 89 in sra_objects.py for actual submission)
+# NOTE: URL in amrcurl is set to TEST server for testing (change line 12 in amrcurl.py for submission to production)
+
+
+
+compare-amr directory contains (among other files)
+===
+amrcurl.py
+amr.py
+antibiotics.txt
+ftper.py
+samp.txt
+sra_objects.py
+validator.py
+val.py
+===
+
+The package is accessed from main file 'validator.py'
+You can run the below to see available options
+python validator.py --help
+
+
+The tool will add directories and files into the working directory so it is reccommended to work outside of compare-amr directory but you must copy over antibiotics.txt to your working directory to have a local list of accepted antibiotics terms.
+
+minimum_samp.txt is an example anitbiogram file. Copy this to your local directory too, for testing. 
+
+Step 1: using option 'validate' (-m validate) on the provided minimum_samp.txt file
+
+python ../compare-amr/validator.py -f minimum_samp.txt -m validate -u Webin-XXX -p PASS -s PRJEBXXXX -c CENT
+
+If all is well, the headers in the antibiogram file are printed and no other messages will appear if there are no errors detected. 
+Webin-XXX must be replaced with your account id
+PASS must be replaced with the password for your account.
+PRJEBXXXX must be replaced with a valid project id (to which you are adding the antibiogram file)
+CENT must be replaced by a valid centre name that is associated with your Webin account
+Use the correct path to call validator.py if 
+
+
+output on success:
+
+['biosample_id', 'species', 'antibiotic_name', 'ast_standard', 'breakpoint_version', 'laboratory_typing_method', 'measurement', 'measurement_units', 'measurement_sign', 'resistance_phenotype', 'platform']
+
+
+
+Step 2: using option 'submit' (-m submit) to submit and receive an ERZ accession for each unique sample in the antibiogram file.
+
+python ../compare-amr/validator.py -f minimum_samp.txt -m submit -u Webin-XXX -p PASS -s PRJEBXXXX -c CENT
+
+The source antibiogram file is split by source sample (column 1). The example file "minimum_samp.txt" has 8 distinct samples (SAMEA3993570, SAMEA3993572, SAMEA3993567, SAMEA3993569, SAMEA3993571, SAMEA3993565, SAMEA3993573, SAMEA3993566) so 8 antibiogram files are created, each in a separate directory which is named by the current month (to help organise future and historic submissions) also included in each directory is a submittable XML submission file and XML analysis file. Each directory is transferred by ftp to your Webin ftp area. The final step is to submit all antibiograms. This is done in one step so that all antibiogram files will have the same submission event id and it will also save making multiple calls to the server. An all-encompasing submission XML file and analysis XML file are created in the working directory. The analysis XML refers to each one of the antibiogram files in the subdirectories. The 2 XML files are sent to the ENA REST server and a receipt in XML format is obtained from the server. If the submission is successful the receipt XML will contain an ERZ (analysis) accession for each antibiogram file. The receipt is printed to standard output when the program has completed. Also look out for the string 'success="true"' for verification that the submission completed without error.
+
+example output on success:
+
+['biosample_id', 'species', 'antibiotic_name', 'ast_standard', 'breakpoint_version', 'laboratory_typing_method', 'measurement', 'measurement_units', 'measurement_sign', 'resistance_phenotype', 'platform']
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="receipt.xsl"?>
+<RECEIPT receiptDate="2017-11-30T15:32:46.640Z" submissionFile="all_anal_sub_Nov-2017.xml" success="true">
+     <ANALYSIS accession="ERZ243560" alias="SAMEA3993570_Nov-2017" status="PRIVATE"/>
+     <ANALYSIS accession="ERZ243561" alias="SAMEA3993572_Nov-2017" status="PRIVATE"/>
+     <ANALYSIS accession="ERZ243562" alias="SAMEA3993567_Nov-2017" status="PRIVATE"/>
+     <ANALYSIS accession="ERZ243563" alias="SAMEA3993569_Nov-2017" status="PRIVATE"/>
+     <ANALYSIS accession="ERZ243564" alias="SAMEA3993571_Nov-2017" status="PRIVATE"/>
+     <ANALYSIS accession="ERZ243565" alias="SAMEA3993565_Nov-2017" status="PRIVATE"/>
+     <ANALYSIS accession="ERZ243566" alias="SAMEA3993573_Nov-2017" status="PRIVATE"/>
+     <ANALYSIS accession="ERZ243567" alias="SAMEA3993566_Nov-2017" status="PRIVATE"/>
+     <SUBMISSION accession="ERA398936" alias="all_anal_sub_Nov-2017"/>
+     <MESSAGES>
+          <INFO>Submission has been rolled back.</INFO>
+          <INFO>This submission is a TEST submission and will be discarded within 24 hours</INFO>
+     </MESSAGES>
+     <ACTIONS>ADD</ACTIONS>
+     <ACTIONS>ROLLBACK</ACTIONS>
+</RECEIPT>
+
+
+Finally:
+Example of trying to submit an antibiogram file with an error in it:
+
+python ../compare-amr/validator.py -f with_error.txt -m submit -u Webin-XXXX -PASS -s PRJEBXXXX -c CENT
+
+['biosample_id', 'species', 'antibiotic_name', 'ast_standard', 'breakpoint_version', 'laboratory_typing_method', 'measurement', 'measurement_units', 'measurement_sign', 'resistance_phenotype', 'platform']
+ERROR: 'amjicillin' is not a valid antibiotic_name name in line number 2.
+1 rows have an error. removing temporary files and exiting ...
+
+In this case, attempt to correct the error and try again. The 'validate' option is recommended when testing for the first time to avoid uneccesary file creation and file upload in case there is an error in the original antibiogram file.

--- a/validator/README.TXT
+++ b/validator/README.TXT
@@ -1,8 +1,3 @@
-# NOTE: all submissions have ROLLBACK for testing (remove line 88 & 89 in sra_objects.py for actual submission)
-# NOTE: URL in amrcurl is set to TEST server for testing (change line 12 in amrcurl.py for submission to production)
-
-
-
 compare-amr directory contains (among other files)
 ===
 amrcurl.py
@@ -26,14 +21,16 @@ minimum_samp.txt is an example anitbiogram file. Copy this to your local directo
 
 Step 1: using option 'validate' (-m validate) on the provided minimum_samp.txt file
 
-python ../compare-amr/validator.py -f minimum_samp.txt -m validate -u Webin-XXX -p PASS -s PRJEBXXXX -c CENT
+python ../compare-amr/validator.py -f minimum_samp.txt -m validate -u Webin-XXX -p PASS -s PRJEBXXXX -c CENT -t
 
 If all is well, the headers in the antibiogram file are printed and no other messages will appear if there are no errors detected. 
 Webin-XXX must be replaced with your account id
 PASS must be replaced with the password for your account.
 PRJEBXXXX must be replaced with a valid project id (to which you are adding the antibiogram file)
 CENT must be replaced by a valid centre name that is associated with your Webin account
-Use the correct path to call validator.py if 
+Use the correct path to call validator.py if it is in a different directory to the working directory
+
+The -t flag means "test" in the command above. It does nothing at this stage but if the 'validate' option was turned off and the submission went through, it would go to the test server instead of the production server. The test server behaves like the production server and you will get back accessions if the submission is good. But the test server is wiped and replaced every day so the accessions will not persist and are not real! 
 
 
 output on success:
@@ -44,7 +41,7 @@ output on success:
 
 Step 2: using option 'submit' (-m submit) to submit and receive an ERZ accession for each unique sample in the antibiogram file.
 
-python ../compare-amr/validator.py -f minimum_samp.txt -m submit -u Webin-XXX -p PASS -s PRJEBXXXX -c CENT
+python ../compare-amr/validator.py -f minimum_samp.txt -m submit -u Webin-XXX -p PASS -s PRJEBXXXX -c CENT -t
 
 The source antibiogram file is split by source sample (column 1). The example file "minimum_samp.txt" has 8 distinct samples (SAMEA3993570, SAMEA3993572, SAMEA3993567, SAMEA3993569, SAMEA3993571, SAMEA3993565, SAMEA3993573, SAMEA3993566) so 8 antibiogram files are created, each in a separate directory which is named by the current month (to help organise future and historic submissions) also included in each directory is a submittable XML submission file and XML analysis file. Each directory is transferred by ftp to your Webin ftp area. The final step is to submit all antibiograms. This is done in one step so that all antibiogram files will have the same submission event id and it will also save making multiple calls to the server. An all-encompasing submission XML file and analysis XML file are created in the working directory. The analysis XML refers to each one of the antibiogram files in the subdirectories. The 2 XML files are sent to the ENA REST server and a receipt in XML format is obtained from the server. If the submission is successful the receipt XML will contain an ERZ (analysis) accession for each antibiogram file. The receipt is printed to standard output when the program has completed. Also look out for the string 'success="true"' for verification that the submission completed without error.
 
@@ -64,21 +61,20 @@ example output on success:
      <ANALYSIS accession="ERZ243567" alias="SAMEA3993566_Nov-2017" status="PRIVATE"/>
      <SUBMISSION accession="ERA398936" alias="all_anal_sub_Nov-2017"/>
      <MESSAGES>
-          <INFO>Submission has been rolled back.</INFO>
           <INFO>This submission is a TEST submission and will be discarded within 24 hours</INFO>
      </MESSAGES>
      <ACTIONS>ADD</ACTIONS>
-     <ACTIONS>ROLLBACK</ACTIONS>
 </RECEIPT>
 
 
 Finally:
 Example of trying to submit an antibiogram file with an error in it:
 
-python ../compare-amr/validator.py -f with_error.txt -m submit -u Webin-XXXX -PASS -s PRJEBXXXX -c CENT
+python ../compare-amr/validator.py -f with_error.txt -m submit -u Webin-XXXX -PASS -s PRJEBXXXX -c CENT -t
 
 ['biosample_id', 'species', 'antibiotic_name', 'ast_standard', 'breakpoint_version', 'laboratory_typing_method', 'measurement', 'measurement_units', 'measurement_sign', 'resistance_phenotype', 'platform']
 ERROR: 'amjicillin' is not a valid antibiotic_name name in line number 2.
 1 rows have an error. removing temporary files and exiting ...
 
 In this case, attempt to correct the error and try again. The 'validate' option is recommended when testing for the first time to avoid uneccesary file creation and file upload in case there is an error in the original antibiogram file.
+

--- a/validator/amr.py
+++ b/validator/amr.py
@@ -1,12 +1,14 @@
 import requests
 import sys
 
+
 class antibiogram:
 		
 		global antibiotic_file
 		global laboratory_typing_methods
 		global dilution_methods
 		global diffusion_methods
+		has_error = 0
 		
 		
 		laboratory_typing_methods=['BROTH DILUTION','MICROBROTH DILUTION','AGAR DILUTION','DISC-DIFFUSION','NEO-SENSITABS','ETEST']
@@ -32,6 +34,7 @@ class antibiogram:
 		def val_biosample_id(self,biosample_id,line_number):
 				if not biosample_id.upper().startswith("SAM"):
 						print "ERROR: %s is not a valid biosample accession in line number %s"%(biosample_id,line_number)
+						self.has_error += 1
 				return biosample_id
 		
 		def val_species(self,species,line_number):
@@ -42,21 +45,23 @@ class antibiogram:
 				if resp.status_code != 200:
 						resp = requests.get(any_name_url)
 						print "ERROR: scientific name for species '%s' does not exist in taxonomy database in line number %s."%(species,line_number)
+						self.has_error += 1
 						if resp.status_code == 200:
 							 print "Some close matches scientific names are:\n%s"%resp.json()[0]['scientificName']
 				
-		#TODOL Clara to check the official antiobiotic names 
 		def val_antibiotic_name(self,antibiotic_name,antibiotic_file,line_number):
 				with open(antibiotic_file) as f:
 						 antibiotics = f.read().upper().splitlines()
 				if antibiotic_name.upper() not in antibiotics:
 					 print "ERROR: '%s' is not a valid antibiotic_name name in line number %s."%(antibiotic_name,line_number)
+					 self.has_error += 1
 				return antibiotic_name
 				
 		def val_ast_standard(self,ast_standard,line_number):
 				accepted_ast_standards=['CLSI','EUCAST','CA-SFM','BSAC','DIN','SIR','WRG']
 				if ast_standard.upper() not in accepted_ast_standards:
 					 print "ERROR: %s is not a valid ast_standard in line number %s."%(ast_standard,line_number)
+					 self.has_error += 1
 				return ast_standard
 				
 		def val_breakpoint_version(self,breakpoint_version,line_number):
@@ -65,6 +70,7 @@ class antibiogram:
 		def val_laboratory_typing_method(self,laboratory_typing_method,line_number):
 				if laboratory_typing_method.upper() not in laboratory_typing_methods:
 					 print "ERROR: %s is not a valid laboratory_typing_method in line number %s."%(laboratory_typing_method,line_number)
+					 self.has_error += 1
 				return laboratory_typing_method
 		
 		def val_measurement(self,measurement,laboratory_typing_method,line_number):
@@ -75,39 +81,49 @@ class antibiogram:
 									try:
 											if not 0.01 <= float(meas) <= 2048:
 													print "ERROR: %s is not a valid measurement, accepted one is between 0.01 and 2048 for dilution methods in line number %s."%(meas,line_number)
+													self.has_error += 1
 									except:
 											print "ERROR: the measurement value format of %s in not correct in line number %s."%(meas,line_number)
+											self.has_error += 1
 											message=str(sys.exc_info()[1])
 											print "    Exception: %s"%message
 								elif laboratory_typing_method.upper() in diffusion_methods:
 									try:
 											if not 6 <= float(meas) <= 99:
 													print "ERROR: %s is not a valid measurement, accepted one is between 6 and 99 for diffusion methods in line number %s."%(meas,line_number)
+													self.has_error += 1
 									except:
 											print "ERROR: the measurement value format of %s in not correct in line number %s."%(meas,line_number)
+											self.has_error += 1
 											message=str(sys.exc_info()[1])
 											print "    Exception: %s"%message
 								else:
 									 print "ERROR: measurement can't be validated as laboratory_typing_method needs to be valid to validate the measurement in line number %s."%line_number
+									 self.has_error += 1
 				else:
 						if laboratory_typing_method.upper() in dilution_methods:
 								try:
 									if not 0.01 <= float(measurement) <= 2048:
 											print "ERROR: %s is not a valid measurement, accepted one is between 0.01 and 2048 for dilution methods in line number %s."%(measurement,line_number)
+											self.has_error += 1
 								except:
 										print "ERROR: the measurement value format of %s in not correct in line number %s."%(measurement,line_number)
+										self.has_error += 1
 										message=str(sys.exc_info()[1])
 										print "    Exception: %s"%message
 						elif laboratory_typing_method.upper() in diffusion_methods:
 								try:
 									if not 6 <= float(measurement) <= 99:
 											print "ERROR: %s is not a valid measurement, accepted one is between 6 and 99 for diffusion methods in line number %s."%(measurement,line_number)
+											self.has_error += 1
 								except:
 										print "ERROR: the measurement value format of %s in not correct in line number %s."%(measurement,line_number)
+										self.has_error += 1
 										message=str(sys.exc_info()[1])
 										print "    Exception: %s"%message
 						else:
 							 print "ERROR: measurement can't be validated as laboratory_typing_method needs to be valid to validate the measurement in line number %s."%line_number
+							 self.has_error += 1
 						
 				return measurement
 				
@@ -115,11 +131,14 @@ class antibiogram:
 				if laboratory_typing_method.upper() in dilution_methods:
 					 if measurement_units.lower() !='mg/l':
 							print "ERROR: %s is not a valid measurement unit, accepted one is 'mg/L' for dilution methods in line number %s."%(measurement_units,line_number)
+							self.has_error += 1
 				elif laboratory_typing_method.upper() in diffusion_methods:
 					 if measurement_units.lower() !='mm':
 							print "ERROR: %s is not a valid measurement unit, accepted one is 'mm' for dilution methods in line number %s."%(measurement_units,line_number)
+							self.has_error += 1
 				else:
 						print "ERROR: measurement unit can't be validated as laboratory_typing_method needs to be valid to validate the measurement unit in line number %s."%line_number
+						self.has_error += 1
 						
 				return measurement_units
 		
@@ -128,12 +147,14 @@ class antibiogram:
 				accepted_val_measurement_signs=['>','<','=','<=','>=']
 				if measurement_sign not in accepted_val_measurement_signs:
 						print "ERROR: %s is not a valid measurement sign. Valid ones are '>','<',<=','>=' and '=' in line number %s."%(measurement_sign,line_number)
+						self.has_error += 1
 				return measurement_sign
 		
 		def val_resistance_phenotype(self,resistance_phenotype,line_number):
 				accepted_resistance_phenotype=['intermediate','susceptible','resistant','non-susceptible','not-defined']
 				if resistance_phenotype not in accepted_resistance_phenotype:
 						print "ERROR: '%s' is not a valid resistance phenotype. Valid ones are 'intermediate','susceptible','resistant','non-susceptible', and 'not-defined' in line number %s"%(resistance_phenotype,line_number)
+						self.has_error += 1
 				return resistance_phenotype
 		
 		def val_platform(self,platform,line_number):

--- a/validator/amrcurl.py
+++ b/validator/amrcurl.py
@@ -1,0 +1,33 @@
+import requests
+import os.path
+import sys
+
+class amrcurl:
+
+    def __init__(self,submission_xml,analysis_xml,account_id,password):
+
+        self.submission_xml=self.check_file(submission_xml)
+        self.analysis_xml=self.check_file(analysis_xml)
+        self.url='https://www-test.ebi.ac.uk/ena/submit/drop-box/submit/?auth=ENA%20' + account_id + '%20' + password 
+        self.post()
+
+
+    def check_file(self, file):
+
+        if os.path.isfile(file):
+            return file
+        else:
+            print "could not find file %s required for sending request for submission. exiting ..."%file
+            sys.exit()
+
+
+
+    def post(self):
+        
+        files = [
+            ('SUBMISSION', open(self.submission_xml, 'rb')),
+            ('ANALYSIS', open(self.analysis_xml, 'rb')),
+        ]
+#        print self.url
+        r = requests.post(self.url, files=files)
+        print(r.text)

--- a/validator/amrcurl.py
+++ b/validator/amrcurl.py
@@ -4,11 +4,14 @@ import sys
 
 class amrcurl:
 
-    def __init__(self,submission_xml,analysis_xml,account_id,password):
+    def __init__(self,submission_xml,analysis_xml,account_id,password,test):
 
         self.submission_xml=self.check_file(submission_xml)
         self.analysis_xml=self.check_file(analysis_xml)
-        self.url='https://www-test.ebi.ac.uk/ena/submit/drop-box/submit/?auth=ENA%20' + account_id + '%20' + password 
+	if test:
+            self.url='https://www-test.ebi.ac.uk/ena/submit/drop-box/submit/?auth=ENA%20' + account_id + '%20' + password 
+	else:
+            self.url='https://www.ebi.ac.uk/ena/submit/drop-box/submit/?auth=ENA%20' + account_id + '%20' + password 
         self.post()
 
 

--- a/validator/antibiotics.txt
+++ b/validator/antibiotics.txt
@@ -322,3 +322,4 @@ vernamycin C
 vertilimicin
 viomycin
 virginiamycin S2
+temocillin

--- a/validator/ftper.py
+++ b/validator/ftper.py
@@ -1,0 +1,49 @@
+from ftplib import FTP
+import sys
+
+class ftper:
+
+    def __init__(self,file_list,u_name,p_word):
+
+        self.pref=file_list
+        self.ftp= FTP('webin.ebi.ac.uk',u_name,p_word)
+        self.contents=self.list()
+        self.make_remote_d()
+        self.quit()
+
+    def make_remote_d(self):
+
+        for prefix in self.pref:
+            file_name = prefix + '/' + prefix + '.txt'
+            xml_name =  prefix + '/' + prefix + '.xml'
+            xml_sub = prefix + '/submission_' + prefix + '.xml'
+            if prefix in self.contents:
+                print "making remote directory '%s' but there is already a remote directory (or file) with this name"%prefix
+                print "exiting program"
+                self.quit()
+                sys.exit()
+            try:
+                upload_file = open(file_name,'r')
+                upload_xml = open(xml_name,'r')
+                upload_sub = open(xml_sub,'r')
+                self.ftp.mkd(prefix)
+                self.ftp.storbinary('STOR ' + file_name, upload_file )
+                self.ftp.storbinary('STOR ' + xml_name, upload_xml )
+                self.ftp.storbinary('STOR ' + xml_sub, upload_sub )
+            except:
+                print "problem reading local file %s and %s and %s and then storing remote file %s and %s and %s" % (file_name,xml_name,xml_sub,file_name,xml_name,xml_sub)
+                str(sys.exc_info()[1])
+                sys.exit(0)
+
+
+    def list(self):
+
+        try:
+            file_listing=self.ftp.nlst()
+        except:
+            print "trouble loading remote file list"
+            print str(sys.exc_info()[1])
+        return file_listing
+
+    def quit(self):
+        self.ftp.quit()

--- a/validator/minimum_samp.txt
+++ b/validator/minimum_samp.txt
@@ -1,0 +1,36 @@
+bioSample_ID	species	antibiotic_name	ast_standard	breakpoint_version	laboratory_typing_method	measurement	measurement_units	measurement_sign	resistance_phenotype	platform
+SAMEA3993565	Escherichia coli	ampicillin	EUCAST	as described in 2013/652/EU	Microbroth dilution	64	mg/L	>	resistant	sensititer
+SAMEA3993573	Escherichia coli	ceftazidime-clavulanic acid	EUCAST	as described in 2013/652/EU	Microbroth dilution	8	mg/L	=	not-defined	sensititer
+SAMEA3993565	Escherichia coli	cefotaxime-clavulanic acid	EUCAST	as described in 2013/652/EU	Microbroth dilution	2	mg/L	=	not-defined	sensititer
+SAMEA3993566	Escherichia coli	ampicillin	EUCAST	as described in 2013/652/EU	Microbroth dilution	64	mg/L	>	resistant	sensititer
+SAMEA3993566	Escherichia coli	cefotaxime-clavulanic acid	EUCAST	as described in 2013/652/EU	Microbroth dilution	0.06	mg/L	<=	not-defined	sensititer
+SAMEA3993567	Escherichia coli	ampicillin	EUCAST	as described in 2013/652/EU	Microbroth dilution	64	mg/L	>	resistant	sensititer
+SAMEA3993567	Escherichia coli	azithromycin	EUCAST	as described in 2013/652/EU	Microbroth dilution	8	mg/L	=	not-defined	sensititer
+SAMEA3993567	Escherichia coli	cefotaxime-clavulanic acid	EUCAST	as described in 2013/652/EU	Microbroth dilution	2	mg/L	=	not-defined	sensititer
+SAMEA3993569	Escherichia coli	ampicillin	EUCAST	as described in 2013/652/EU	Microbroth dilution	64	mg/L	>	resistant	sensititer
+SAMEA3993569	Escherichia coli	azithromycin	EUCAST	as described in 2013/652/EU	Microbroth dilution	4	mg/L	=	not-defined	sensititer
+SAMEA3993569	Escherichia coli	cefotaxime-clavulanic acid	EUCAST	as described in 2013/652/EU	Microbroth dilution	0.125	mg/L	=	not-defined	sensititer
+SAMEA3993570	Escherichia coli	azithromycin	EUCAST	as described in 2013/652/EU	Microbroth dilution	4	mg/L	=	not-defined	sensititer
+SAMEA3993570	Escherichia coli	cefotaxime-clavulanic acid	EUCAST	as described in 2013/652/EU	Microbroth dilution	0.5	mg/L	=	not-defined	sensititer
+SAMEA3993573	Escherichia coli	nalidixic acid	EUCAST	as described in 2013/652/EU	Microbroth dilution	4	mg/L	<=	susceptible	sensititer
+SAMEA3993570	Escherichia coli	cefepime	EUCAST	as described in 2013/652/EU	Microbroth dilution	0.06	mg/L	<=	susceptible	sensititer
+SAMEA3993571	Escherichia coli	ampicillin	EUCAST	as described in 2013/652/EU	Microbroth dilution	64	mg/L	>	resistant	sensititer
+SAMEA3993571	Escherichia coli	azithromycin	EUCAST	as described in 2013/652/EU	Microbroth dilution	4	mg/L	=	not-defined	sensititer
+SAMEA3993572	Escherichia coli	ampicillin	EUCAST	as described in 2013/652/EU	Microbroth dilution	64	mg/L	>	resistant	sensititer
+SAMEA3993572	Escherichia coli	azithromycin	EUCAST	as described in 2013/652/EU	Microbroth dilution	4	mg/L	=	not-defined	sensititer
+SAMEA3993566	Escherichia coli	azithromycin	EUCAST	as described in 2013/652/EU	Microbroth dilution	3	mg/L	=	not-defined	sensititer
+SAMEA3993573	Escherichia coli	ampicillin	EUCAST	as described in 2013/652/EU	Microbroth dilution	64	mg/L	>	resistant	sensititer
+SAMEA3993573	Escherichia coli	azithromycin	EUCAST	as described in 2013/652/EU	Microbroth dilution	4	mg/L	=	not-defined	sensititer
+SAMEA3993573	Escherichia coli	cefotaxime-clavulanic acid	EUCAST	as described in 2013/652/EU	Microbroth dilution	2	mg/L	=	not-defined	sensititer
+SAMEA3993573	Escherichia coli	cefepime	EUCAST	as described in 2013/652/EU	Microbroth dilution	0.25	mg/L	=	resistant	sensititer
+SAMEA3993573	Escherichia coli	cefotaxime	EUCAST	as described in 2013/652/EU	Microbroth dilution	4	mg/L	=	resistant	sensititer
+SAMEA3993573	Escherichia coli	cefoxitin	EUCAST	as described in 2013/652/EU	Microbroth dilution	32	mg/L	=	resistant	sensititer
+SAMEA3993573	Escherichia coli	chloramphenicol	EUCAST	as described in 2013/652/EU	Microbroth dilution	8	mg/L	<=	susceptible	sensititer
+SAMEA3993573	Escherichia coli	ciprofloxacin	EUCAST	as described in 2013/652/EU	Microbroth dilution	0.03	mg/L	=	susceptible	sensititer
+SAMEA3993570	Escherichia coli	ampicillin	EUCAST	as described in 2013/652/EU	Microbroth dilution	64	mg/L	>	resistant	sensititer
+SAMEA3993573	Escherichia coli	colistin	EUCAST	as described in 2013/652/EU	Microbroth dilution	1	mg/L	<=	susceptible	sensititer
+SAMEA3993573	Escherichia coli	ceftazidime	EUCAST	as described in 2013/652/EU	Microbroth dilution	8	mg/L	=	resistant	sensititer
+SAMEA3993573	Escherichia coli	ertapenem	EUCAST	as described in 2013/652/EU	Microbroth dilution	0.06	mg/L	=	susceptible	sensititer
+SAMEA3993573	Escherichia coli	gentamicin	EUCAST	as described in 2013/652/EU	Microbroth dilution	0.5	mg/L	<=	susceptible	sensititer
+SAMEA3993573	Escherichia coli	imipenem	EUCAST	as described in 2013/652/EU	Microbroth dilution	0.25	mg/L	=	susceptible	sensititer
+SAMEA3993573	Escherichia coli	meropenem	EUCAST	as described in 2013/652/EU	Microbroth dilution	0.03	mg/L	<=	susceptible	sensititer

--- a/validator/sra_objects.py
+++ b/validator/sra_objects.py
@@ -85,9 +85,8 @@ class submission:
 		actionsElt=etree.SubElement(submissionElt, 'ACTIONS')
 		actionElt=etree.SubElement(actionsElt,'ACTION')
 		actionSub=etree.SubElement(actionElt,self.action,source=self.source_xml,schema=self.schema)
-		actionElt2=etree.SubElement(actionsElt,'ACTION')
-		actionRollback=etree.SubElement(actionElt2,'ROLLBACK')
-#		print lxml.etree.tostring(submission_xml, pretty_print=True,xml_declaration = True, encoding='UTF-8')
+#		actionElt2=etree.SubElement(actionsElt,'ACTION')
+#		actionRollback=etree.SubElement(actionElt2,'ROLLBACK')
 		submission_xml.write(self.submission_xml_file,pretty_print=True,xml_declaration = True, encoding='UTF-8')
 
 

--- a/validator/sra_objects.py
+++ b/validator/sra_objects.py
@@ -1,0 +1,101 @@
+from lxml import etree
+import lxml.builder 
+
+#sudo pip install --upgrade setuptools
+#wget https://bootstrap.pypa.io/ez_setup.py -O - | sudo python
+#sudo pip install lxml
+
+class analysis_amr:
+	
+	
+	def __init__(self,alias,centre_name,sample_accession,study_accession,analysis_files,title,description,analysis_xml_file):
+		self.alias=alias
+		self.analysis_xml_file=analysis_xml_file
+		#self.analysis_centre=analysis_centre
+		self.centre_name=centre_name
+                self.sample_accession=sample_accession
+		self.study_accession=study_accession
+		self.analysis_files=analysis_files
+		self.title=title
+		self.description=description
+		
+	def next_el(self, next_alias, next_samp_acc, next_files, next_title, next_desc):
+		self.alias=next_alias
+                self.sample_accession=next_samp_acc
+		self.analysis_files=next_files
+		self.title=next_title
+		self.description=next_desc
+
+	def build_set(self):
+		self.analysis_set = etree.Element('ANALYSIS_SET')
+		self.analysis_xml = etree.ElementTree(self.analysis_set)
+		
+	def build_anal(self):
+		analysisElt = etree.SubElement(self.analysis_set, 'ANALYSIS', alias=self.alias , center_name=self.centre_name)
+
+		title = etree.SubElement(analysisElt, 'TITLE')
+		title.text = self.title
+		description = etree.SubElement(analysisElt, 'DESCRIPTION')
+		description.text = self.description
+		studyrefElt = etree.SubElement(analysisElt, 'STUDY_REF', accession=self.study_accession)
+		samplerefElt = etree.SubElement(analysisElt, 'SAMPLE_REF', accession=self.sample_accession)
+		analysis_type = etree.SubElement(analysisElt, 'ANALYSIS_TYPE')
+		type = etree.SubElement(analysis_type, 'AMR_ANTIBIOGRAM')
+		files = etree.SubElement(analysisElt, 'FILES')
+		file1Elt = etree.SubElement(files,'FILE', filename=self.analysis_files[0].file_name,filetype=self.analysis_files[0].file_type,checksum_method="MD5", checksum=self.analysis_files[0].file_md5)
+
+	def write_anal(self):
+		self.analysis_xml.write(self.analysis_xml_file,pretty_print=True,xml_declaration = True, encoding='UTF-8')
+
+	def build_analysis(self): #to be deleted
+		analysis_set = etree.Element('ANALYSIS_SET')
+		analysis_xml = etree.ElementTree(analysis_set)
+		analysisElt = etree.SubElement(analysis_set, 'ANALYSIS', alias=self.alias , center_name=self.centre_name)
+		title = etree.SubElement(analysisElt, 'TITLE')
+		title.text = self.title
+		description = etree.SubElement(analysisElt, 'DESCRIPTION')
+		description.text = self.description
+		studyrefElt = etree.SubElement(analysisElt, 'STUDY_REF', accession=self.study_accession)
+		samplerefElt = etree.SubElement(analysisElt, 'SAMPLE_REF', accession=self.sample_accession)
+		analysis_type = etree.SubElement(analysisElt, 'ANALYSIS_TYPE')
+		type = etree.SubElement(analysis_type, 'AMR_ANTIBIOGRAM')
+		files = etree.SubElement(analysisElt, 'FILES')
+		file1Elt = etree.SubElement(files,'FILE', filename=self.analysis_files[0].file_name,filetype=self.analysis_files[0].file_type,checksum_method="MD5", checksum=self.analysis_files[0].file_md5)
+#		print lxml.etree.tostring(analysis_xml, pretty_print=True,xml_declaration = True, encoding='UTF-8')
+		analysis_xml.write(self.analysis_xml_file,pretty_print=True,xml_declaration = True, encoding='UTF-8')
+		
+		
+
+
+class submission:
+	
+	
+	def __init__(self,alias,submission_centre,action,submission_xml_file,source_xml,schema):
+		self.submission_centre=submission_centre
+		self.action=action
+		self.source_xml=source_xml
+		self.alias=alias
+		self.submission_xml_file=submission_xml_file
+		self.schema=schema
+	
+	def build_submission(self):
+		submission_set = etree.Element('SUBMISSION_SET')
+		submission_xml = etree.ElementTree(submission_set)
+		submissionElt = etree.SubElement(submission_set, 'SUBMISSION', alias=self.alias , center_name=self.submission_centre)
+		actionsElt=etree.SubElement(submissionElt, 'ACTIONS')
+		actionElt=etree.SubElement(actionsElt,'ACTION')
+		actionSub=etree.SubElement(actionElt,self.action,source=self.source_xml,schema=self.schema)
+		actionElt2=etree.SubElement(actionsElt,'ACTION')
+		actionRollback=etree.SubElement(actionElt2,'ROLLBACK')
+#		print lxml.etree.tostring(submission_xml, pretty_print=True,xml_declaration = True, encoding='UTF-8')
+		submission_xml.write(self.submission_xml_file,pretty_print=True,xml_declaration = True, encoding='UTF-8')
+
+
+	
+	
+class analysis_file:
+
+	def __init__(self,file_name,file_type,file_md5):
+		self.file_name=file_name
+		self.file_type=file_type
+		self.file_md5=file_md5

--- a/validator/val.py
+++ b/validator/val.py
@@ -1,0 +1,149 @@
+import os
+import datetime
+from amr import antibiogram
+
+
+class val:
+
+    month = datetime.date.today().strftime('_%b-%Y')
+    error_detect = 0
+    files_created=set()
+
+    def __init__(self,arguments):
+
+
+
+        self.args = arguments
+        self.antibiograms = self.get_antibiogram_data()
+
+#        self.month = datetime.date.today().strftime('_%b-%Y')+".txt"
+#        self.error_detect = 0
+
+
+    def validate_header(self,header_line):
+        values = header_line.strip().lower().split("\t")
+        header_len= len(values)
+        exit = 1
+        print values
+        if header_len <10:
+            print "ERORR: The header of the file (line number 0) has less number of column than the minimum accepted column (10).\nIt is possible that your file is not a tab delimited file (tsv)"
+            exit=0
+        if "biosample_id" not in values:
+            print "ERROR: biosample_id column is missing."
+            exit=0
+        if "species" not in values:
+            print "ERROR: species column is missing."
+            exit=0
+        if "antibiotic_name" not in values:
+            print "ERROR: antibiotic_name column is missing."
+            exit=0
+        if "ast_standard" not in values:
+            print "ERROR: ast_standard column is missing."
+            exit=0
+        if "breakpoint_version" not in values:
+            print "ERROR: breakpoint_version column is missing."
+            exit=0
+        if "laboratory_typing_method" not in values:
+            print "ERROR: laboratory_typing_method column is missing."
+            exit=0
+        if "measurement" not in values:
+            print "ERROR: measurement column is missing."
+            exit=0
+        if "measurement_units" not in values:
+            print "ERROR: measurement_units column is missing."
+            exit=0
+        if "measurement_sign" not in values:
+            print "ERROR: measurement_sign column is missing."
+            exit=0
+        if "resistance_phenotype" not in values:
+            print "ERROR: resistance_phenotype column is missing."
+            exit=0
+        if exit==0:
+            print "Validator has been exited because of above error(s) and has't been proceeded to rest of validation"
+            sys.exit(0)	 
+
+        return header_line
+
+
+    def get_antibiogram_data(self):
+
+	
+        tsv_file = self.args.filename
+	with open(tsv_file) as f:
+		lines = f.readlines()
+	
+	header_line = self.validate_header(lines[0])  
+	values = lines[0].strip().lower().split("\t")
+	header_len=len(values)
+	biosample_id_set=set()
+ 	species_set=set()
+
+	antibiograms=list()
+
+   
+	biosample_id_index=values.index("biosample_id")
+	species_index=values.index("species")
+	antibiotic_name_index=values.index("antibiotic_name")
+	ast_standard_index=values.index("ast_standard")
+	breakpoint_version_index=values.index("breakpoint_version")
+	laboratory_typing_method_index=values.index("laboratory_typing_method")
+	measurement_index=values.index("measurement")
+	measurement_units_index=values.index("measurement_units")
+	measurement_sign_index=values.index("measurement_sign")
+	resistance_phenotype_index=values.index("resistance_phenotype")
+	platform_index=values.index("platform")
+
+	
+	
+	
+	i=1
+	for line in lines:
+		columns = line.strip().split("\t")
+		if len(columns) <10:
+			print "ERROR: line number %s of the file has less number of column than the minimum accepted column (10).\nIt is possible that your file has missed tabs"%str(i)
+			sys.exit(0)
+		
+		if i>1:
+			if len(columns)!=header_len:
+				print "ERROR: Line number:%s has wrong number of column. It has %s columns while your header has %s columns."%(i,len(columns),header_len)
+				print "The wrong line has these columns:%s"%columns
+				
+			else:
+				biosample_id=columns[biosample_id_index]
+#				biosample_id_set.add(biosample_id)
+				species=columns[species_index]
+				species_set.add(species)
+				antibiotic_name=columns[antibiotic_name_index]
+				ast_standard=columns[ast_standard_index]
+				breakpoint_version=columns[breakpoint_version_index]
+				laboratory_typing_method=columns[laboratory_typing_method_index]
+				measurement=columns[measurement_index]
+				measurement_units=columns[measurement_units_index]
+				measurement_sign=columns[measurement_sign_index]
+				resistance_phenotype=columns[resistance_phenotype_index]
+				platform=columns[platform_index]
+					
+				
+
+				antibio=antibiogram(biosample_id,species,antibiotic_name,ast_standard,breakpoint_version,
+									laboratory_typing_method,measurement,measurement_units,measurement_sign,
+									resistance_phenotype,platform,i)
+
+				if self.args.mode == "submit": 
+					if antibio.has_error:
+						self.error_detect += 1 # could put bad antibio in separate list to 'antibiograms'
+					else:
+                                                file_name = biosample_id + self.month
+                                                self.files_created.add(file_name)
+						with open(file_name + ".txt", "a") as singsamp:
+							if biosample_id not in biosample_id_set:
+								singsamp.write(header_line)
+							singsamp.write(line)
+						biosample_id_set.add(biosample_id)
+				antibiograms.append(antibio)
+		i += 1
+ 
+        self.header_line=header_line
+	return antibiograms
+
+

--- a/validator/validator.py
+++ b/validator/validator.py
@@ -108,6 +108,7 @@ def get_args():
 	parser.add_argument('-p', '--password', type=str, help='Please provide a password if you are using submit mode.', required=False)
        	parser.add_argument('-c', '--center', type=str, help='Please provide the centre name for your Webin account if you are using submit mode.', required=False)
        	parser.add_argument('-s', '--study', type=str, help='Please provide the study id (looks like PRJEBXXX) to add the antibiograms to if you are using submit mode.', required=False)
+       	parser.add_argument('-t', '--test', action='store_true', help='If you are using the submit flag, this option will send the submission to the test server. To submit to the production server leave this option out', required=False)
 
 
 	args=parser.parse_args()
@@ -134,4 +135,4 @@ if __name__ == '__main__':
 		build_dir(antibiograms)
 		all_sub=make_xml(antibiograms) #all_sub[0] = submission xml, all_sub[1] = analysis xml
 		ftper=ftper(antibiograms.files_created,args.user_name,args.password)
-		crl=amrcurl(all_sub[0],all_sub[1],args.user_name,args.password)
+		crl=amrcurl(all_sub[0],all_sub[1],args.user_name,args.password,args.test)

--- a/validator/validator.py
+++ b/validator/validator.py
@@ -1,140 +1,137 @@
-from amr import antibiogram
+from val import val
+from sra_objects import analysis_amr
+from sra_objects import analysis_file
+from sra_objects import submission
 import sys
+import os
+import glob
+import shutil
+import argparse
+import hashlib
+from ftper import ftper
+from amrcurl import amrcurl
 
-#TODO: check to see if a file tab file DONE
-#TODO: check to see all the headers column are available DONE
-#TODO: check the taxonomy/species  DONE
-#TODO: add ignore case to all the string matches DONE
-#TODO: check a 10 column file to works Not needed
-#TODO: check to see all the sample_ids are the same DONE
-#TODO: check to see if all the species are the same DONE
-#TODO: accept  the range to the measurment 
-#TODO: let everybody know about the removal of #
-#TODO: ignore the empty lines
 
-def validate_header(header_line):
-	values =header_line.strip().lower().split("\t")
-	header_len=len(values)
-	exit=1
-	print values
-	if header_len <10:
-		print "ERORR: The header of the file (line number 0) has less number of column than the minimum accepted column (10).\nIt is possible that your file is not a tab delimited file (tsv)"
-		exit=0
-	
-	if "biosample_id" not in values:
-		print "ERROR: biosample_id column is missing."
-		exit=0
-	if "species" not in values:
-		print "ERROR: species column is missing."
-		exit=0
-	if "antibiotic_name" not in values:
-		print "ERROR: antibiotic_name column is missing."
-		exit=0
-	if "ast_standard" not in values:
-		print "ERROR: ast_standard column is missing."
-		exit=0
-	if "breakpoint_version" not in values:
-		print "ERROR: breakpoint_version column is missing."
-		exit=0
-	if "laboratory_typing_method" not in values:
-		print "ERROR: laboratory_typing_method column is missing."
-		exit=0
-	if "measurement" not in values:
-		print "ERROR: measurement column is missing."
-		exit=0
-	if "measurement_units" not in values:
-		print "ERROR: measurement_units column is missing."
-		exit=0
-	if "measurement_sign" not in values:
-		print "ERROR: measurement_sign column is missing."
-		exit=0
-	if "resistance_phenotype" not in values:
-		print "ERROR: resistance_phenotype column is missing."
-		exit=0
-		
-	if exit==0:
-		print "Validator has been exited because of above error(s) and has't been proceeded to rest of validation"
+
+def build_dir(rows):
+
+	new_dirs = []
+	if rows.error_detect:
+		print "%s rows have an error. removing temporary files and exiting ..."%str(rows.error_detect) #temporary files are from val.get_antibiogram_data()
+#		for f in glob.glob("*"+month):
+#			os.remove(f)
+
+		for prefix in rows.files_created:
+			expectedfname = prefix + ".txt"
+			try:
+				os.remove(expectedfname)
+			except OSError as e:
+				print "trouble removing %s. Exiting without continuing."%expectedfname
+				print e
+				sys.exit(0)
 		sys.exit(0)
-	 
-	 
-	
+				
+	else:
+		for prefix in rows.files_created:
+			directoryname= prefix
+			expectedfname= prefix + ".txt"
+			try:
+				os.makedirs(directoryname)
+			except OSError as e:
+				print "trouble creating a directory called %s. Exiting without continuing"%directoryname
+				print e
+				sys.exit(0)
+			try:
+				shutil.move(expectedfname,directoryname)
+			except IOError as e:
+				print "trouble moving file %s to directory %s. Exiting without continuing"%(expectedfname,directoryname)
+				print e
+				sys.exit(0)
 
 
+			
+	return
 
-def get_antibiogram_data(tsv_file):
-	with open(tsv_file) as f:
-		lines = f.readlines()
-	
-	validate_header(lines[0])   
-	values = lines[0].strip().lower().split("\t")
-	header_len=len(values)
-	biosample_id_set=set()
-	species_set=set()
-	
 
-   
-	biosample_id_index=values.index("biosample_id")
-	species_index=values.index("species")
-	antibiotic_name_index=values.index("antibiotic_name")
-	ast_standard_index=values.index("ast_standard")
-	breakpoint_version_index=values.index("breakpoint_version")
-	laboratory_typing_method_index=values.index("laboratory_typing_method")
-	measurement_index=values.index("measurement")
-	measurement_units_index=values.index("measurement_units")
-	measurement_sign_index=values.index("measurement_sign")
-	resistance_phenotype_index=values.index("resistance_phenotype")
-	platform_index=values.index("platform")
+def make_xml(rows):
 
-	antibiograms=list()
-	
-	
-	
-	i=1
-	for line in lines:
-		columns = line.strip().split("\t")
-		if len(columns) <10:
-			print "ERORR: line number %s of the file has less number of column than the minimum accepted column (10).\nIt is possible that your file has missed tabs"%str(i)
+	xml_name="all_anal" + rows.month + ".xml"
+	xml_name_sub="all_anal_sub" + rows.month + ".xml"
+	all_anal=analysis_amr("temp",rows.args.center,"temp",rows.args.study,list(),"temp","temp",xml_name) 
+	sub=submission("all_anal_sub" + rows.month,rows.args.center,"ADD",xml_name_sub,xml_name,"analysis")
+	sub.build_submission()
+	all_anal.build_set() 
+	for d in rows.files_created:
+		sample_accession= d.split('_')[0]
+		analysis_files=list()
+		root_analysis_files=list()
+		filename= d + ".txt"
+		filename_full= d + "/" + d + ".txt"
+		try:
+			file_md5= hashlib.md5(open(filename_full, 'rb').read()).hexdigest()
+		except:
+			print "trouble opening and creating md5sum for file %s. Exiting without continuing"%filename_full
+			print str(sys.exc_info()[1])
 			sys.exit(0)
-		
-		if i>1:
-			if len(columns)!=header_len:
-				print "ERROR: Line number:%s has wrong number of column. It has %s columns while your header has %s columns."%(i,len(columns),header_len)
-				print "The wrong line has these columns:%s"%columns
-				
-			else:
-				biosample_id=columns[biosample_id_index]
-				biosample_id_set.add(biosample_id)
-				species=columns[species_index]
-				species_set.add(species)
-				antibiotic_name=columns[antibiotic_name_index]
-				ast_standard=columns[ast_standard_index]
-				breakpoint_version=columns[breakpoint_version_index]
-				laboratory_typing_method=columns[laboratory_typing_method_index]
-				measurement=columns[measurement_index]
-				measurement_units=columns[measurement_units_index]
-				measurement_sign=columns[measurement_sign_index]
-				resistance_phenotype=columns[resistance_phenotype_index]
-				platform=columns[platform_index]
-					
-				
 
-				antibio=antibiogram(biosample_id,species,antibiotic_name,ast_standard,breakpoint_version,
-									laboratory_typing_method,measurement,measurement_units,measurement_sign,
-									resistance_phenotype,platform,i)
-
-				antibiograms.append(antibio)
-		i += 1
-		
-	if len(biosample_id_set) > 1:
-		print "ERROR: there are multiple biosample_id in this file. biosample_id shall be unique. current ones are:\n %s"%list(biosample_id_set)
-	if len(species_set) > 1:
-		print "ERROR: there are multiple species in this file. Species shall be unique. Current ones are:\n %s"%list(species_set)
-	
-	return antibiograms
+		file_detail= analysis_file(filename,'tab',file_md5)
+		root_file_detail= analysis_file(filename_full,'tab',file_md5) 
+		analysis_files.append(file_detail)
+		root_analysis_files.append(root_file_detail) 
+		title= "Antibiogram for study %s, sample %s"%(rows.args.study,sample_accession)
+		analysis_xml_relative= d + ".xml"
+		analysis_xml= d + "/" + d + ".xml"
+		submission_xml= d + "/submission_" + d + ".xml"
+		anal = analysis_amr(d,rows.args.center,sample_accession,rows.args.study,analysis_files,title,title,analysis_xml)
+#		anal.build_analysis()
+		anal.build_set()
+		anal.build_anal()
+		anal.write_anal() # these must happen in this order. no check in place yet
+		lsub=submission("submission_" + d,rows.args.center,"ADD",submission_xml,analysis_xml_relative,"analysis")
+		lsub.build_submission()
+		all_anal.next_el(d,sample_accession,root_analysis_files,title,title)
+		all_anal.build_anal()
 
 
+
+	all_anal.write_anal() 
+	return [xml_name_sub,xml_name]
+
+
+def get_args():
+
+	parser = argparse.ArgumentParser(description='Script for validating AMR antibiograms and optionally submitting them to public repository ENA')
+	parser.add_argument ('-f','--filename',type=str, help='Please provide the name of AMR antibiogram file')
+#	parser.add_argument('-p', '--properties_file', type=str, help='Please provide the properties file that is required by SELECTA system', required=False)
+	parser.add_argument('-m', '--mode', type=str, help='Options for mode are validate/submit', choices=["validate","submit"], nargs='?', required=False)
+	parser.add_argument('-u', '--user_name', type=str, help='Please provide a username if you are using submit mode. Looks like Webin-XXX', required=False)
+	parser.add_argument('-p', '--password', type=str, help='Please provide a password if you are using submit mode.', required=False)
+       	parser.add_argument('-c', '--center', type=str, help='Please provide the centre name for your Webin account if you are using submit mode.', required=False)
+       	parser.add_argument('-s', '--study', type=str, help='Please provide the study id (looks like PRJEBXXX) to add the antibiograms to if you are using submit mode.', required=False)
+
+
+	args=parser.parse_args()
+	if args.mode is None:
+		args.mode = "validate"
+
+	if args.mode == "submit" :
+		if not args.user_name or not args.password or not args.center or not args.study:
+			print "if using submit mode you must provide: Webin account username, password and center name. As well as a valid study id"
+			parser.print_help()
+			sys.exit()
+	return args
+
+
+
+# NOTE: all submissions have ROLLBACK for testing (remove line 88 & 89 in sra_objects.py for actual submission)
+# NOTE: URL in amrcurl is set to TEST server for testing (change line 12 in amrcurl.py for submission to production)
 
 if __name__ == '__main__':
 	
-	antibiograms=get_antibiogram_data(sys.argv[1])
-	
+	args = get_args()
+	antibiograms=val(args)
+	if args.mode == "submit":
+		build_dir(antibiograms)
+		all_sub=make_xml(antibiograms) #all_sub[0] = submission xml, all_sub[1] = analysis xml
+		ftper=ftper(antibiograms.files_created,args.user_name,args.password)
+		crl=amrcurl(all_sub[0],all_sub[1],args.user_name,args.password)


### PR DESCRIPTION
extended functionality:
argument passing added, provides a submit mode which splits AMR file by sample, creates directory for each, creates submission XMLs for each directory (not used for submission, provided for reference), creates one pair of submission XMLs for ALL directories (used in actual submission), uploads directories and contents to ftp server, carries out submission, prints XML receipt to standard out.

currently set on rollback and set to use the test server. To submit to production, 2 simple edits required (detailed in READMET.TXT).

guide for testing:
see README.TXT
